### PR TITLE
Patch security vulnerabilities and update deployment pipeline for upgraded home server

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,28 +12,36 @@ jobs:
     runs-on: self-hosted
     
     steps:
-      - name: File Permissions
+      - name: Ensure permissions allow for the removal of existing files in the runner working directory
         run: |
             sudo chown -R $USER:$USER .
-      - name: Checkout
+      - name: Checkout files
         uses: actions/checkout@v4
+      - name: Copy files to desired directory and set file permissions
+        env:
+          TARGET_FOLDER: ${{ secrets.TARGET_FOLDER }}
+        run: |
+            sudo rsync -a . "$TARGET_FOLDER"
+            sudo chown -R $USER:$USER "$TARGET_FOLDER"
+            sudo chmod u+x "$TARGET_FOLDER/backend/shutDownOldVersion.sh"
+            sudo chmod u+x "$TARGET_FOLDER/backend/mvnw"
       - name: Create secrets.properties
         env:
-          PROPERTIES: ${{ secrets.SECRETS_PROPERTIES }}
+          SECRETS_PROPERTIES: ${{ secrets.SECRETS_PROPERTIES }}
+          TARGET_FOLDER: ${{ secrets.TARGET_FOLDER }}
         run: |
-            echo "$PROPERTIES" > backend/src/main/resources/secrets.properties
-      - name: Shut Down Old Version
-        run: |
-            cd backend
-            bash shutDownOldVersion.sh
-            sleep 5
-      - name: Copy files to desired directory and run Spring Boot
+            echo "$SECRETS_PROPERTIES" > "$TARGET_FOLDER/backend/src/main/resources/secrets.properties"
+      - name: Shut down old version
         env:
-          TARGET: ${{ secrets.TARGET_FOLDER }}
+          TARGET_FOLDER: ${{ secrets.TARGET_FOLDER }}
         run: |
-            sudo find "$TARGET" &> /dev/null && sudo rm -r "$TARGET"
-            sudo mkdir "$TARGET"
-            sudo mv -v ./* "$TARGET" &> /dev/null
-            cd "$TARGET"
-            cd backend
-            sudo nohup mvn spring-boot:run -Dspring-boot.run.jvmArguments="-XX:MaxRAM=1000m -XX:+UseSerialGC -XX:InitiatingHeapOccupancyPercent=7" > spring-log.txt 2>&1 &
+            "$TARGET_FOLDER/backend/shutDownOldVersion.sh"
+            sleep 5
+      - name: Run Spring Boot application
+        env:
+          TARGET_FOLDER: ${{ secrets.TARGET_FOLDER }}
+          TARGET_LOG_FOLDER: ${{ secrets.TARGET_LOG_FOLDER }}
+        run: |
+            cd "$TARGET_FOLDER/backend"
+            DATE=$(date "+%Y%m%d")
+            sudo nohup ./mvnw spring-boot:run -Dspring-boot.run.jvmArguments="-XX:MaxRAM=4096m -XX:+UseSerialGC -XX:InitiatingHeapOccupancyPercent=7" >> "$TARGET_LOG_FOLDER/spring-log_$DATE.txt" 2>&1 &

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.3.13</version>
+		<version>3.4.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.jasonpyau</groupId>
@@ -69,12 +69,12 @@
 		<dependency>
 			<groupId>software.amazon.awssdk</groupId>
 			<artifactId>s3</artifactId>
-			<version>2.29.43</version>
+			<version>2.32.25</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.tika</groupId>
 			<artifactId>tika-core</artifactId>
-			<version>3.0.0</version>
+			<version>3.2.2</version>
 		</dependency>
 		<dependency>
 			<groupId>net.coobird</groupId>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.3.11</version>
+		<version>3.3.13</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.jasonpyau</groupId>

--- a/backend/shutDownOldVersion.sh
+++ b/backend/shutDownOldVersion.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
 if sudo lsof -t -i:9080 > /dev/null; then 
+    echo "Killing process on port 9080."
     sudo kill -9 $(sudo lsof -t -i:9080) &> /dev/null 
 fi
+echo "Done."

--- a/backend/src/main/java/com/jasonpyau/chatapp/config/SecurityConfig.java
+++ b/backend/src/main/java/com/jasonpyau/chatapp/config/SecurityConfig.java
@@ -42,7 +42,7 @@ public class SecurityConfig {
                     .requestMatchers("/api/groupchat/**", "/api/message/**", "/api/users/**", "/api/attachment/**").hasAnyRole(Role.USER.toString(), Role.ADMIN.toString())
                     .requestMatchers("/topic/**", "/app/**", "/ws/**").hasAnyRole(Role.USER.toString(), Role.ADMIN.toString())
                     .requestMatchers("/built/**").permitAll()
-                    .requestMatchers("/", "/error", "login", "logout", "/api/login/user", "/api/login/principal").permitAll()
+                    .requestMatchers("/", "/error", "/login", "/logout", "/api/login/user", "/api/login/principal").permitAll()
                     .anyRequest().authenticated();
             })
             .oauth2Login(oauth -> {

--- a/backend/src/main/java/com/jasonpyau/chatapp/service/AmazonS3Service.java
+++ b/backend/src/main/java/com/jasonpyau/chatapp/service/AmazonS3Service.java
@@ -12,6 +12,8 @@ import lombok.Getter;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.checksums.RequestChecksumCalculation;
+import software.amazon.awssdk.core.checksums.ResponseChecksumValidation;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -47,6 +49,8 @@ public class AmazonS3Service {
                                 .credentialsProvider(StaticCredentialsProvider.create(awsBasicCredentials))
                                 .region(Region.of("auto"))
                                 .forcePathStyle(true)
+                                .requestChecksumCalculation(RequestChecksumCalculation.WHEN_REQUIRED)
+                                .responseChecksumValidation(ResponseChecksumValidation.WHEN_REQUIRED)
                                 .build();
     }
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.8.2",
+        "axios": "^0.30.1",
         "filesize": "^10.1.6",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -444,12 +444,12 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
-      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
+      "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.30.1.tgz",
+      "integrity": "sha512-2XabsR1u0/B6OoKy57/xJmPkQiUvdoV93oW4ww+Xjee7C2er/O5U77lvqycDkT2VQDtfjYcjw8ZV8GDaoqwjHQ==",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
+        "follow-redirects": "^1.15.4",
+        "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -520,6 +520,18 @@
       },
       "engines": {
         "node": ">=6.14.2"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/camel-case": {
@@ -845,6 +857,19 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.13",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.13.tgz",
@@ -885,11 +910,52 @@
         "node": ">=4"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.4.tgz",
       "integrity": "sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw==",
       "dev": true
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/es5-ext": {
       "version": "0.10.64",
@@ -1129,12 +1195,14 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       },
       "engines": {
@@ -1145,9 +1213,43 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/glob-to-regexp": {
@@ -1155,6 +1257,17 @@
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "dev": true
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
@@ -1171,11 +1284,35 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -1471,6 +1608,14 @@
       "dev": true,
       "dependencies": {
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/merge-stream": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
   "author": "Jason Yau",
   "license": "MIT",
   "dependencies": {
-    "axios": "^1.8.2",
+    "axios": "^0.30.1",
     "filesize": "^10.1.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",


### PR DESCRIPTION
- Update deployment pipeline for upgraded home server
- Bump Spring Boot 3.4.9: CVE-2025-52520, CVE-2025-53506
- Bump AWS SDK for Java 2.32.25: CVE-2025-55163
- Bump Apache Tika 3.2.2: CVE-2025-54988
- Use axios ^0.30.1: CVE-2025-7783
- Fix request signature error when using updated AWS SDK with Cloudflare R2 by doing checksums only when required ([changed with AWS SDK >= 2.30.0](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/s3-checksums.html))