### PR TITLE
Bump versions: Spring Boot 4.0.2, axios 0.30.2, lodash 4.17.23

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.4.9</version>
+		<version>4.0.2</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.jasonpyau</groupId>
@@ -31,7 +31,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
+			<artifactId>spring-boot-starter-webmvc</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "axios": "^0.30.1",
+        "axios": "^0.30.2",
         "filesize": "^10.1.6",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -444,9 +444,10 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.30.1.tgz",
-      "integrity": "sha512-2XabsR1u0/B6OoKy57/xJmPkQiUvdoV93oW4ww+Xjee7C2er/O5U77lvqycDkT2VQDtfjYcjw8ZV8GDaoqwjHQ==",
+      "version": "0.30.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.30.2.tgz",
+      "integrity": "sha512-0pE4RQ4UQi1jKY6p7u6i1Tkzqmu+d+/tHS7Q7rKunWLB9WyilBTpHHpXzPNMDj5hTbK0B0PTLSz07yqMBiF6xg==",
+      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.4",
         "form-data": "^4.0.4",
@@ -1585,10 +1586,11 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
   "author": "Jason Yau",
   "license": "MIT",
   "dependencies": {
-    "axios": "^0.30.1",
+    "axios": "^0.30.2",
     "filesize": "^10.1.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",


### PR DESCRIPTION
- Bump Spring Boot 4.0.2: CVE-2025-68161, CVE-2025-58057, CVE-2025-67735, CVE-2025-58056, CVE-2025-55754, CVE-2025-55752, CVE-2025-61795
- Changes to dependencies due to Spring Boot 4.0.2 ([Spring-Boot-4.0-Migration-Guide](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-4.0-Migration-Guide))
- Bump axios 0.30.2: CVE-2025-58754
- Bump lodash 4.17.23: CVE-2025-13465